### PR TITLE
Fixed QueryTest that instantiates ObjectBuilder directly.

### DIFF
--- a/mql/src/test/java/com/mulesoft/mql/QueryTest.java
+++ b/mql/src/test/java/com/mulesoft/mql/QueryTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+import static com.mulesoft.mql.ObjectBuilder.newObject;
 import static com.mulesoft.mql.Restriction.*;
 
 import junit.framework.Assert;
@@ -21,7 +22,7 @@ public class QueryTest extends Assert {
             .orderby("income")
             .max(3)
             .where(eq(property("division"), "Sales"))
-            .select(new ObjectBuilder() 
+            .select(newObject()
                       .set("name", "firstName + ' ' + lastName")
                       .set("income", "income")).build();
         


### PR DESCRIPTION
Fixed an usage of ObjectBuilder creation in the test. The test would compile only if it were under com.mulesoft.mql package as ObjectBuilder has protected access. Made it consistent with other tests.
